### PR TITLE
Fix search index generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,18 @@ Activate the extension in `config.rb`:
 activate :lunr
 ```
 
-Mark the files you wanna index in the [frontmatter](https://middlemanapp.com/basics/frontmatter/):
+All published posts will be indexed by default. Unpublished posts are ignored
+by default. To ignore published posts you don't want to index, add the
+following to their [frontmatter](https://middlemanapp.com/basics/frontmatter/):
 
 ```
-index: true
+index: false
 ```
 
 Create a JSON template `source/search.json.erb` and generate the index and map:
 
 ```html
-<%= JSON.generate(generate_search_index({data: [:title, :description]})) %>
+<%= JSON.generate(generate_search_index({data: [:title, :description]}), max_nesting: false) %>
 ```
 - The generated json will include the lunr.js index under the `index` key and a map that translates lunr.js references to your middleman pages under the `map` key.
 - The `data` argument is an array of [frontmatter](https://middlemanapp.com/basics/frontmatter/) variables that you'd like to include in the map.

--- a/lib/middleman-lunr/indexer.rb
+++ b/lib/middleman-lunr/indexer.rb
@@ -21,23 +21,23 @@ module Middleman::Lunr
       end
 
       @extension.sitemap.resources.each do |res|
-        if res.data[:index]
-          doc = { id: res.url.to_s }
-          key = res.url.to_s
-          data = {}
+        next if not_indexable?(res)
 
-          if options[:body]
-            doc[:body] = File.read(res.source_file)
-          end
+        doc = { id: res.url.to_s }
+        key = res.url.to_s
+        data = {}
 
-          options[:data].each do |d|
-            doc[d] = res.data[d]
-            data[d.to_s] = res.data[d]
-          end
-
-          docs << doc
-          map[key] = data
+        if options[:body]
+          doc[:body] = File.read(res.source_file)
         end
+
+        options[:data].each do |d|
+          doc[d] = res.data[d]
+          data[d.to_s] = res.data[d]
+        end
+
+        docs << doc
+        map[key] = data
       end
 
       cxt = V8::Context.new
@@ -58,9 +58,15 @@ module Middleman::Lunr
         idx.add(doc)
       end
 
-      data = JSON.parse(idx.dumpIndex())
+      data = JSON.parse(idx.dumpIndex(), max_nesting: false)
 
       { index: data, map: map }
+    end
+
+    private
+
+    def not_indexable?(res)
+      res.data[:title].nil? || res.data[:index] == false || res.data[:published] == false
     end
   end
 end


### PR DESCRIPTION
There were a few problems with the indexing and generation.

First, the indexer was indexing the entire project contents instead
of just the articles. The correct method to iterate over is
`page_articles`, not `sitemap.resources`.

Second, the JSON parsing and generation were resulting in a
"nesting too deep" error. To fix this, we need to add
`max_nesting: false` to both the `JSON.parse` call in `indexer.rb` and in
the `JSON.generate` call in `search.json`.

Finally, I also made the indexer index all posts by default, except for
unpublished posts and posts that specify `index: false` because it
is more common to want to index the majority of your posts. This way,
you only need to manually specify `index: false` for a small amount of
posts that you want to ignore, as opposed to having to manually specify
`index: true` for hundreds of posts.
